### PR TITLE
DNX template for new Okta SSO image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,14 @@ RUN pip3 install --upgrade pip
 RUN pip3 install awscli
 
 # move okta jar into bin
-RUN curl -sSL ${OKTA_RELEASE} > /usr/bin/okta-aws-cli.jar
+RUN curl -sSL ${OKTA_RELEASE} > /bin/okta-aws-cli.jar
 
-# create a auto assume wrapper
-COPY awscli /usr/bin/awscli
+# create /work (main folder)
+RUN mkdir /work/
 
-# set as default command
-CMD ["awscli"]
+# copy the authentication script from docker entrypoint
+COPY src/docker-entrypoint.sh /bin/docker-entrypoint.sh
+RUN chmod +x /bin/docker-entrypoint.sh
+
+
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-.SILENT:
-OKTA_VERSION = 1.0.10
-TAG = $(OKTA_VERSION)-1
-IMAGE_NAME ?= contino/okta-aws:$(TAG)
+OKTA_VERSION=1.0.10
+TAG=$(OKTA_VERSION)-dnx1.0.0
+IMAGE_NAME?=dnxsolutions/aws-okta-auth:$(TAG)
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ Here are some quick environment variables to get you started:
 - `OKTA_USERNAME` - Your personal Okta username, if not set will be prompted to enter in manually
 - `OKTA_AWS_PROFILE` - Custom name for the okta profile to use (default: 'default')
 
-If requiring an assume role after your primary Okta login, these variables
-can be used to automatically assume into the role desired:
-
-- `AWS_ASSUME_ROLE_ARN` - The full ARN of the account and role you wish to assume into after Okta authentication
-- `AWS_ASSUME_SESSION_NAME` - Custom session name to be used in assuming (default: 'OktaAssumeRole')
-
 ### Configuration File
 If wanting to store all configuration for Okta in a static file instead, you
 have the functionality to bind mount a configuration file directly into the

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -9,29 +9,6 @@ java "-Duser.home=${HOME}" \
      -classpath /bin/okta-aws-cli.jar com.okta.tools.awscli \
      --profile "${OKTA_AWS_PROFILE:-default}" sts get-caller-identity
 
-# Assume role if specified
-if [ -n "${AWS_ASSUME_ROLE_ARN:-}" ]; then
-  echo -e "\nAssuming role as: ${AWS_ASSUME_ROLE_ARN}"
-  assumed_role_details=$(aws sts assume-role \
-    --role-arn "${AWS_ASSUME_ROLE_ARN}" \
-    --role-session-name "${AWS_ASSUME_SESSION_NAME:-OktaAssumeRole}" \
-    --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-    --output text)
-
-  # Split results
-  aws_access_key_id=$(echo "${assumed_role_details}" | cut -f1)
-  aws_secret_access_key=$(echo "${assumed_role_details}" | cut -f2)
-  aws_session_token=$(echo "${assumed_role_details}" | cut -f3)
-
-  # Set aws credentials
-  aws configure set aws_access_key_id "${aws_access_key_id}"
-  aws configure set aws_secret_access_key "${aws_secret_access_key}"
-  aws configure set aws_session_token "${aws_session_token}"
-
-  # Print out secondary role information
-  aws sts get-caller-identity
-fi
-
 echo "" >> /work/.env
 echo AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) >> /work/.env
 echo AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) >> /work/.env

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -6,7 +6,7 @@ aws configure set region "${OKTA_AWS_DEFAULT_REGION:-ap-southeast-2}"
 
 # Primary OKTA login
 java "-Duser.home=${HOME}" \
-     -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli \
+     -classpath /bin/okta-aws-cli.jar com.okta.tools.awscli \
      --profile "${OKTA_AWS_PROFILE:-default}" sts get-caller-identity
 
 # Assume role if specified
@@ -31,3 +31,10 @@ if [ -n "${AWS_ASSUME_ROLE_ARN:-}" ]; then
   # Print out secondary role information
   aws sts get-caller-identity
 fi
+
+echo "" >> /work/.env
+echo AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id) >> /work/.env
+echo AWS_SECRET_ACCESS_KEY=$(aws configure get aws_secret_access_key) >> /work/.env
+echo AWS_SECURITY_TOKEN=$(aws configure get aws_security_token) >> /work/.env
+echo AWS_SESSION_EXPIRATION=$(aws configure get aws_session_expiration) >> /work/.env
+echo AWS_SESSION_TOKEN=$(aws configure get aws_session_token) >> /work/.env


### PR DESCRIPTION
### New image for Okta SSO via AWS STS

This image is based on a fork from **contino/docker-okta-aws** and contains the following updates:

- Transfer of **awscli** to **src/docker-entrypoint.sh**.
- Removal of AssumeRole feature since we should use the DNX pattern via **.env.assume**.
- Update of image name and tags for docker hub publishing.
- Update of README file.